### PR TITLE
[Blackjack - Step2] Submit Farhana's mission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,72 @@
 # kotlin-blackjack
 
-A simple kotlin project implementation of the classic Blackjack card game where a player competes against a dealer. 
-The goal is to get as close to 21 as possible without going over.
+A simple Kotlin implementation of the classic Blackjack game, where players compete against a dealer. 
+The goal is to get as close to 21 as possible without exceeding it with a betting system.
 
 ## Features 
-- Input View 
+
+### Input View 
 - [x] Ask user inputs for player name
-- [x] Get list of names from the user input
+- [x] Get a list of names from the user input
+- [x] Ask each of the player's betting amounts
 - [x] Ask player's choice to draw card or stay 
 
-- Card
+### Card
 - [x] Create Enum class - Ranks
 - [x] Create Enum class - Suits
 - [x] Create Class - Card
 - [x] Determine the value of each card
 
-- Deck
+### Deck
 - [x] Prepare deck
 - [x] Shuffle cards
+- [x] Validation on drawing more than available cards
 
-- Participant : abstract class 
+### Participant : abstract class 
 - [x] Draw card
-- [x] Calculate total value of the cards
-- [x] Update status of a participant
+- [x] Calculate the total value of the cards
+- [x] Common logics for players and dealer (card handling, score calculation, blackjack/bust check)
 
-- Dealer
+### Dealer
 - [x] Use Participant abstract class
-- [x] Implement additional methods to draw card
+- [x] Implement additional methods to draw card following Blackjack rules (draws up to 16, stands on 17+)
+- [x] Calculate the final earnings for a dealer based on all players' outcomes
 
-- Player
+### Player
 - [x] Use Participant abstract class
+- [x] Places a bet
+- [x] Draw cards and update earnings based on game outcome
+- [x] Calculate the final earnings for players (Blackjack = 1.5*bet, tie = 0, loss = -bet)
 
-- Game (controller)
+### Players
+- [x] Wraps list of Player instances
+- [x] Provides utility methods like `forEach` and `toList`
+
+### Participants
+- [x] Combine Dealer and Players into a single unit
+- [x] Deal initial cards to all participants
+- [x] Run dealer’s turn logic
+- [x] Evaluate results for all players
+
+### Game (Controller)
 - [x] Initialize Game
-- [x] Assign two cards to every member
+- [x] Manage game flow (deal, draw, dealer turn)
 - [x] Offer possibility to get a new card
-- [x] Check status
+- [x] Coordinate user input and output
 - [x] Retrieve Winning Information
 
-- Result 
-- [x] Get total value of the cards
-- [x] Process Winning Information
+### OutputView
+- [x] Display initial cards (with dealer showing only one)
+- [x] Show each player’s hand as they draw
+- [x] Show dealer’s draw message if needed
+- [x] Display final hands with total values
+- [x] Display the final earnings result for dealer and players
 
-- OutputView
-- [x] Display cards
-- [x] Display dealer message (if 16 or less)
-- [x] Display all the cards with total value
-- [x] Display Winning Result
+## Blackjack Rules Implemented
+- Aces can count as 1 or 11
+- Blackjack on initial two cards gives 1.5x the bet
+- Player loses the entire bet if busted
+- Dealer stands at 17 or more
+- If both dealer and player have blackjack, bet is returned
+- Dealer bust results in automatic player wins
+

--- a/src/main/kotlin/blackjack/controller/Game.kt
+++ b/src/main/kotlin/blackjack/controller/Game.kt
@@ -13,7 +13,11 @@ class Game {
 
     fun startGame() {
         val names = InputView.askPlayerNames()
-        val players = Players(names.map { Player(it) })
+        val players = Players(names.map {
+            val bet = InputView.askPlayerBet(it)
+            Player(it, bet)
+        })
+
         val dealer = Dealer()
         val participants = Participants(players, dealer)
 

--- a/src/main/kotlin/blackjack/controller/Game.kt
+++ b/src/main/kotlin/blackjack/controller/Game.kt
@@ -13,10 +13,13 @@ class Game {
 
     fun startGame() {
         val names = InputView.askPlayerNames()
-        val players = Players(names.map {
-            val bet = InputView.askPlayerBet(it)
-            Player(it, bet)
-        })
+        val players =
+            Players(
+                names.map {
+                    val bet = InputView.askPlayerBet(it)
+                    Player(it, bet)
+                },
+            )
 
         val dealer = Dealer()
         val participants = Participants(players, dealer)
@@ -31,12 +34,15 @@ class Game {
             }
         }
 
-        if (dealer.mustDraw()) {
+        while (dealer.mustDraw()) {
             OutputView.showDealerDrawsCard()
+            dealer.drawCard(deck.draw())
         }
         participants.dealerTurn(deck)
 
         OutputView.showFinalHands(dealer, players.toList())
+
+        participants.evaluateResults()
         OutputView.showFinalResults(dealer, players.toList())
     }
 }

--- a/src/main/kotlin/blackjack/model/Dealer.kt
+++ b/src/main/kotlin/blackjack/model/Dealer.kt
@@ -3,6 +3,10 @@ package blackjack.model
 class Dealer : Participant("Dealer") {
     fun mustDraw(): Boolean = total() <= DEALER_DRAW_LIMIT
 
+    fun returnWinningMoneyForDealer(players: List<Player>): Int {
+        return players.sumOf { -it.returnWinningMoneyForPlayer() }
+    }
+
     companion object {
         const val DEALER_DRAW_LIMIT = 16
     }

--- a/src/main/kotlin/blackjack/model/Participant.kt
+++ b/src/main/kotlin/blackjack/model/Participant.kt
@@ -12,7 +12,7 @@ abstract class Participant(open val name: String) {
     private fun calculateTotalValueOfCards(): Int {
         var total = cardsInHand.sumOf { it.rank.value }
         var aceCounter = checkAces()
-        while (total > BUST_LIMIT && aceCounter > 0) {
+        while (total > IS_BLACKJACK && aceCounter > 0) {
             total -= 10
             aceCounter--
         }
@@ -21,13 +21,13 @@ abstract class Participant(open val name: String) {
 
     fun total(): Int = calculateTotalValueOfCards()
 
-    fun isBusted(): Boolean = total() > BUST_LIMIT
+    fun isBusted(): Boolean = total() > IS_BLACKJACK
 
     fun isStillInGame(): Boolean = !isBusted()
 
-    fun isBlackjack(): Boolean = cardsInHand.size == 2 && total() == 21
+    fun isBlackjack(): Boolean = cardsInHand.size == 2 && total() == IS_BLACKJACK
 
     companion object {
-        const val BUST_LIMIT = 21
+        const val IS_BLACKJACK = 21
     }
 }

--- a/src/main/kotlin/blackjack/model/Participant.kt
+++ b/src/main/kotlin/blackjack/model/Participant.kt
@@ -25,6 +25,8 @@ abstract class Participant(open val name: String) {
 
     fun isStillInGame(): Boolean = !isBusted()
 
+    fun isBlackjack(): Boolean = cardsInHand.size == 2 && total() == 21
+
     companion object {
         const val BUST_LIMIT = 21
     }

--- a/src/main/kotlin/blackjack/model/Participants.kt
+++ b/src/main/kotlin/blackjack/model/Participants.kt
@@ -3,6 +3,8 @@ package blackjack.model
 class Participants(private val players: Players, private val dealer: Dealer) {
     fun all(): List<Participant> = listOf(dealer) + players.toList()
 
+    fun getPlayers(): List<Player> = players.toList()
+
     fun dealInitialCards(deck: Deck) {
         all().forEach {
             it.drawCard(deck.draw(2))
@@ -13,5 +15,9 @@ class Participants(private val players: Players, private val dealer: Dealer) {
         while (dealer.mustDraw()) {
             dealer.drawCard(deck.draw())
         }
+    }
+
+    fun evaluateResults() {
+        players.forEach { it.updateWinningMoney(dealer) }
     }
 }

--- a/src/main/kotlin/blackjack/model/Player.kt
+++ b/src/main/kotlin/blackjack/model/Player.kt
@@ -8,19 +8,18 @@ class Player(name: String, val bet: Int) : Participant(name) {
     }
 
     fun updateWinningMoney(dealer: Dealer) {
-        winningMoney = when {
-            isBlackjack() && dealer.isBlackjack() -> 0
-            isBlackjack() -> (bet * 1.5).toInt()
-            dealer.isBusted() -> bet
-            total() > dealer.total() -> bet
-            total() == dealer.total() -> 0
-            else -> -bet
-        }
+        winningMoney =
+            when {
+                isBlackjack() && dealer.isBlackjack() -> 0
+                isBlackjack() -> (bet * 1.5).toInt()
+                dealer.isBusted() -> bet
+                total() > dealer.total() -> bet
+                total() == dealer.total() -> 0
+                else -> -bet
+            }
     }
 
-    fun returnWinningMoney(): Int{
+    fun returnWinningMoney(): Int {
         return winningMoney
     }
-
-
 }

--- a/src/main/kotlin/blackjack/model/Player.kt
+++ b/src/main/kotlin/blackjack/model/Player.kt
@@ -19,7 +19,7 @@ class Player(name: String, val bet: Int) : Participant(name) {
             }
     }
 
-    fun returnWinningMoney(): Int {
+    fun returnWinningMoneyForPlayer(): Int {
         return winningMoney
     }
 }

--- a/src/main/kotlin/blackjack/model/Player.kt
+++ b/src/main/kotlin/blackjack/model/Player.kt
@@ -10,7 +10,7 @@ class Player(name: String, val bet: Int) : Participant(name) {
     fun updateWinningMoney(dealer: Dealer) {
         winningMoney =
             when {
-                isBlackjack() && dealer.isBlackjack() -> 0
+                isBlackjack() && dealer.isBlackjack() -> bet
                 isBlackjack() -> (bet * 1.5).toInt()
                 dealer.isBusted() -> bet
                 total() > dealer.total() -> bet

--- a/src/main/kotlin/blackjack/model/Player.kt
+++ b/src/main/kotlin/blackjack/model/Player.kt
@@ -1,7 +1,26 @@
 package blackjack.model
 
-class Player(name: String) : Participant(name) {
+class Player(name: String, val bet: Int) : Participant(name) {
+    private var winningMoney: Int = 0
+
     fun drawAndUpdate(deck: Deck) {
         drawCard(deck.draw())
     }
+
+    fun updateWinningMoney(dealer: Dealer) {
+        winningMoney = when {
+            isBlackjack() && dealer.isBlackjack() -> 0
+            isBlackjack() -> (bet * 1.5).toInt()
+            dealer.isBusted() -> bet
+            total() > dealer.total() -> bet
+            total() == dealer.total() -> 0
+            else -> -bet
+        }
+    }
+
+    fun returnWinningMoney(): Int{
+        return winningMoney
+    }
+
+
 }

--- a/src/main/kotlin/blackjack/view/InputView.kt
+++ b/src/main/kotlin/blackjack/view/InputView.kt
@@ -17,6 +17,7 @@ object InputView {
     }
 
     fun askPlayerBet(name: String): Int {
+        println()
         println("Enter $name’s betting amount:")
         return try {
             readLine()?.toIntOrNull()?.takeIf { it > 0 } ?: askPlayerBet(name)

--- a/src/main/kotlin/blackjack/view/InputView.kt
+++ b/src/main/kotlin/blackjack/view/InputView.kt
@@ -16,6 +16,15 @@ object InputView {
         }
     }
 
+    fun askPlayerBet(name: String): Int {
+        println("Enter $name’s betting amount:")
+        return try {
+            readLine()?.toIntOrNull()?.takeIf { it > 0 } ?: askPlayerBet(name)
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("Betting amount must be greater than 0")
+        }
+    }
+
     fun askToDrawCard(name: String): Boolean {
         println("Would $name like to draw another card? (y for yes, n for no)")
         val choice = readln()

--- a/src/main/kotlin/blackjack/view/InputView.kt
+++ b/src/main/kotlin/blackjack/view/InputView.kt
@@ -17,8 +17,7 @@ object InputView {
     }
 
     fun askPlayerBet(name: String): Int {
-        println()
-        println("Enter $name’s betting amount:")
+        println("\nEnter $name’s betting amount:")
         return try {
             readLine()?.toIntOrNull()?.takeIf { it > 0 } ?: askPlayerBet(name)
         } catch (e: IllegalArgumentException) {

--- a/src/main/kotlin/blackjack/view/OutputView.kt
+++ b/src/main/kotlin/blackjack/view/OutputView.kt
@@ -31,9 +31,8 @@ object OutputView {
         dealer: Dealer,
         players: List<Player>,
     ) {
-        println()
         val playerNames = players.joinToString(", ") { it.name }
-        println("Dealing two cards to dealer, $playerNames.")
+        println("\nDealing two cards to dealer, $playerNames.")
 
         println("Dealer: ${formatCard(dealer.cardsInHand[0])}")
 

--- a/src/main/kotlin/blackjack/view/OutputView.kt
+++ b/src/main/kotlin/blackjack/view/OutputView.kt
@@ -66,15 +66,10 @@ object OutputView {
         dealer: Dealer,
         players: List<Player>,
     ) {
-        val dealerWins = players.count { it.isBusted() || it.total() < dealer.total() }
-        val dealerLoses = players.size - dealerWins
-
-        println("## Final Results")
-        println("Dealer: $dealerWins Win $dealerLoses Lose")
-        players.forEach { player ->
-            val result =
-                if (player.isBusted() || (!dealer.isBusted() && dealer.total() >= player.total())) "Lose" else "Win"
-            println("${player.name}: $result")
+        println("\n## Final Earnings")
+        println("Dealer: ${dealer.returnWinningMoneyForDealer(players)}")
+        players.forEach {
+            println("${it.name}: ${it.returnWinningMoneyForPlayer()}")
         }
     }
 }

--- a/src/test/kotlin/blackjack/model/DealerTest.kt
+++ b/src/test/kotlin/blackjack/model/DealerTest.kt
@@ -66,7 +66,6 @@ class DealerTest {
         assertThat(result).isEqualTo(-10000) // Dealer pays 1 player's win
     }
 
-
     @Test
     fun `should return 0 when tie`() {
         val dealer = Dealer()

--- a/src/test/kotlin/blackjack/model/DealerTest.kt
+++ b/src/test/kotlin/blackjack/model/DealerTest.kt
@@ -1,10 +1,10 @@
 package blackjack.model
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 class DealerTest {
     @Test
@@ -38,7 +38,7 @@ class DealerTest {
     }
 
     @Test
-    fun `should return positive amount when players lose`() {
+    fun `should return correct amount when players lose`() {
         val dealer = Dealer()
         val player = Player("pobi", 10000)
 
@@ -53,7 +53,7 @@ class DealerTest {
     }
 
     @Test
-    fun `should return negative amount when player wins`() {
+    fun `should return correct amount when player wins`() {
         val dealer = Dealer()
         val player = Player("jason", 10000)
 
@@ -65,6 +65,7 @@ class DealerTest {
         val result = dealer.returnWinningMoneyForDealer(listOf(player))
         assertThat(result).isEqualTo(-10000) // Dealer pays 1 player's win
     }
+
 
     @Test
     fun `should return 0 when tie`() {

--- a/src/test/kotlin/blackjack/model/DealerTest.kt
+++ b/src/test/kotlin/blackjack/model/DealerTest.kt
@@ -1,5 +1,6 @@
 package blackjack.model
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -34,5 +35,48 @@ class DealerTest {
 
         dealer.drawCard(listOf(Card(Rank.ACE, Suit.DIAMONDS)))
         assertEquals(18, dealer.total()) // ace1=11 + six=6 + ace2=1, total =18
+    }
+
+    @Test
+    fun `should return positive amount when players lose`() {
+        val dealer = Dealer()
+        val player = Player("pobi", 10000)
+
+        // simulate dealer win: dealer has higher total
+        dealer.drawCard(listOf(Card(Rank.TEN, Suit.SPADES), Card(Rank.NINE, Suit.CLUBS))) // 19
+        player.drawCard(listOf(Card(Rank.TEN, Suit.HEARTS), Card(Rank.EIGHT, Suit.DIAMONDS))) // 18
+
+        player.updateWinningMoney(dealer)
+
+        val result = dealer.returnWinningMoneyForDealer(listOf(player))
+        assertThat(result).isEqualTo(10000) // Dealer earns 1 player's loss
+    }
+
+    @Test
+    fun `should return negative amount when player wins`() {
+        val dealer = Dealer()
+        val player = Player("jason", 10000)
+
+        dealer.drawCard(listOf(Card(Rank.FIVE, Suit.SPADES), Card(Rank.SIX, Suit.CLUBS))) // 11
+        player.drawCard(listOf(Card(Rank.TEN, Suit.HEARTS), Card(Rank.KING, Suit.DIAMONDS))) // 20
+
+        player.updateWinningMoney(dealer)
+
+        val result = dealer.returnWinningMoneyForDealer(listOf(player))
+        assertThat(result).isEqualTo(-10000) // Dealer pays 1 player's win
+    }
+
+    @Test
+    fun `should return 0 when tie`() {
+        val dealer = Dealer()
+        val player = Player("alex", 10000)
+
+        dealer.drawCard(listOf(Card(Rank.NINE, Suit.SPADES), Card(Rank.TWO, Suit.HEARTS))) // 11
+        player.drawCard(listOf(Card(Rank.SIX, Suit.DIAMONDS), Card(Rank.FIVE, Suit.CLUBS))) // 11
+
+        player.updateWinningMoney(dealer)
+
+        val result = dealer.returnWinningMoneyForDealer(listOf(player))
+        assertThat(result).isEqualTo(0)
     }
 }

--- a/src/test/kotlin/blackjack/model/ParticipantsTest.kt
+++ b/src/test/kotlin/blackjack/model/ParticipantsTest.kt
@@ -1,5 +1,6 @@
 package blackjack.model
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -7,7 +8,7 @@ class ParticipantsTest {
     @Test
     fun `should deal 2 cards to each participant`() {
         val deck = Deck()
-        val players = Players(listOf(Player("P1", 100000), Player("P2",200000)))
+        val players = Players(listOf(Player("P1", 100000), Player("P2", 200000)))
         val dealer = Dealer()
         val participants = Participants(players, dealer)
 
@@ -17,5 +18,17 @@ class ParticipantsTest {
         participants.all().forEach {
             assertEquals(2, it.cardsInHand.size)
         }
+    }
+
+    @Test
+    fun `should evaluate winningMoney after game`() {
+        val deck = Deck()
+        val players = Players(listOf(Player("P1", 100000), Player("P2", 200000)))
+        val dealer = Dealer()
+        val participants = Participants(players, dealer)
+        participants.dealInitialCards(deck)
+        participants.dealerTurn(deck)
+        participants.evaluateResults()
+        assertThat(participants.getPlayers().all { it.returnWinningMoneyForPlayer() in -200000..300000 })
     }
 }

--- a/src/test/kotlin/blackjack/model/ParticipantsTest.kt
+++ b/src/test/kotlin/blackjack/model/ParticipantsTest.kt
@@ -7,7 +7,7 @@ class ParticipantsTest {
     @Test
     fun `should deal 2 cards to each participant`() {
         val deck = Deck()
-        val players = Players(listOf(Player("P1"), Player("P2")))
+        val players = Players(listOf(Player("P1", 100000), Player("P2",200000)))
         val dealer = Dealer()
         val participants = Participants(players, dealer)
 

--- a/src/test/kotlin/blackjack/model/PlayerTest.kt
+++ b/src/test/kotlin/blackjack/model/PlayerTest.kt
@@ -1,9 +1,9 @@
 package blackjack.model
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 class PlayerTest {
     @Test
@@ -59,6 +59,16 @@ class PlayerTest {
         dealer.drawCard(listOf(Card(Rank.FIVE, Suit.CLUBS), Card(Rank.FOUR, Suit.DIAMONDS)))
         player.updateWinningMoney(dealer)
         assertThat(player.returnWinningMoneyForPlayer()).isEqualTo(15000)
+    }
+
+    @Test
+    fun `should calculate correct winning money if player and dealer both have blackjack`() {
+        val dealer = Dealer()
+        val player = Player("pobi", 10000)
+        player.drawCard(listOf(Card(Rank.ACE, Suit.SPADES), Card(Rank.KING, Suit.HEARTS)))
+        dealer.drawCard(listOf(Card(Rank.ACE, Suit.CLUBS), Card(Rank.KING, Suit.DIAMONDS)))
+        player.updateWinningMoney(dealer)
+        assertThat(player.returnWinningMoneyForPlayer()).isEqualTo(10000)
     }
 
     @Test

--- a/src/test/kotlin/blackjack/model/PlayerTest.kt
+++ b/src/test/kotlin/blackjack/model/PlayerTest.kt
@@ -58,7 +58,7 @@ class PlayerTest {
         player.drawCard(listOf(Card(Rank.ACE, Suit.SPADES), Card(Rank.KING, Suit.HEARTS)))
         dealer.drawCard(listOf(Card(Rank.FIVE, Suit.CLUBS), Card(Rank.FOUR, Suit.DIAMONDS)))
         player.updateWinningMoney(dealer)
-        assertThat(player.returnWinningMoney()).isEqualTo(15000)
+        assertThat(player.returnWinningMoneyForPlayer()).isEqualTo(15000)
     }
 
     @Test
@@ -77,7 +77,7 @@ class PlayerTest {
         dealer.drawCard(listOf(Card(Rank.FIVE, Suit.SPADES))) // total = 14
 
         player.updateWinningMoney(dealer)
-        assertThat(player.returnWinningMoney()).isEqualTo(10000)
+        assertThat(player.returnWinningMoneyForPlayer()).isEqualTo(10000)
     }
 
     @Test
@@ -90,6 +90,6 @@ class PlayerTest {
 
         player.updateWinningMoney(dealer)
 
-        assertThat(player.returnWinningMoney()).isEqualTo(-10000)
+        assertThat(player.returnWinningMoneyForPlayer()).isEqualTo(-10000)
     }
 }

--- a/src/test/kotlin/blackjack/model/PlayerTest.kt
+++ b/src/test/kotlin/blackjack/model/PlayerTest.kt
@@ -8,13 +8,19 @@ import kotlin.test.assertEquals
 class PlayerTest {
     @Test
     fun `player should have given name`() {
-        val player = Player("Alex")
+        val player = Player("Alex", 20000)
         assertEquals("Alex", player.name)
     }
 
     @Test
+    fun `player should have correct amount of bet`() {
+        val player = Player("Alex", 20000)
+        assertEquals(20000, player.bet)
+    }
+
+    @Test
     fun `draw method should add cards to cardsInHand`() {
-        val player = Player("Alex")
+        val player = Player("Alex", 20000)
         val card = Card(Rank.KING, Suit.HEARTS)
         assertThat(player.cardsInHand).hasSize(0)
         player.drawCard(listOf(card))
@@ -23,7 +29,7 @@ class PlayerTest {
 
     @Test
     fun `player total calculates aces correctly`() {
-        val player = Player("Farhana")
+        val player = Player("Farhana", 10000)
         player.drawCard(listOf(Card(Rank.ACE, Suit.HEARTS), Card(Rank.SIX, Suit.CLUBS)))
         assertEquals(17, player.total()) // ace=11 + six=6, total =17
 
@@ -33,15 +39,59 @@ class PlayerTest {
 
     @Test
     fun `player busts when total exceeds 21`() {
-        val player = Player("Alex")
+        val player = Player("Alex", 20000)
         player.drawCard(listOf(Card(Rank.TEN, Suit.HEARTS), Card(Rank.KING, Suit.SPADES), Card(Rank.TWO, Suit.CLUBS)))
         assertTrue(player.isBusted()) // total = 22
     }
 
     @Test
     fun `player is still in game when total is 21 or less`() {
-        val player = Player("Farhana")
+        val player = Player("Farhana", 10000)
         player.drawCard(listOf(Card(Rank.TEN, Suit.HEARTS), Card(Rank.ACE, Suit.SPADES)))
         assertTrue(player.isStillInGame()) // total = 21
     }
+
+    @Test
+    fun `should calculate correct winning money for blackjack`() {
+        val dealer = Dealer()
+        val player = Player("pobi", 10000)
+        player.drawCard(listOf(Card(Rank.ACE, Suit.SPADES), Card(Rank.KING, Suit.HEARTS)))
+        dealer.drawCard(listOf(Card(Rank.FIVE, Suit.CLUBS), Card(Rank.FOUR, Suit.DIAMONDS)))
+        player.updateWinningMoney(dealer)
+        assertThat(player.returnWinningMoney()).isEqualTo(15000)
+    }
+
+    @Test
+    fun `should calculate correct winning money without blackjack`() {
+        val dealer = Dealer()
+        val player = Player("pobi", 10000)
+
+        //initial draw
+        player.drawCard(listOf(Card(Rank.SIX, Suit.SPADES), Card(Rank.KING, Suit.HEARTS))) // total = 16
+        dealer.drawCard(listOf(Card(Rank.FIVE, Suit.CLUBS), Card(Rank.FOUR, Suit.DIAMONDS))) //total = 9
+
+        //player draws again
+        player.drawCard(cards = listOf(Card(Rank.FIVE, Suit.DIAMONDS))) // total = 21
+
+        //dealer draws again
+        dealer.drawCard(listOf(Card(Rank.FIVE, Suit.SPADES))) // total = 14
+
+        player.updateWinningMoney(dealer)
+        assertThat(player.returnWinningMoney()).isEqualTo(10000)
+    }
+
+    @Test
+    fun `should lose bet when busted`() {
+        val dealer = Dealer()
+        val player = Player("test", 10000)
+
+        player.drawCard(listOf(Card(Rank.TEN, Suit.HEARTS), Card(Rank.SIX, Suit.CLUBS)))
+        dealer.drawCard(listOf(Card(Rank.NINE, Suit.HEARTS), Card(Rank.NINE, Suit.DIAMONDS)))
+
+        player.updateWinningMoney(dealer)
+
+        assertThat(player.returnWinningMoney()).isEqualTo(-10000)
+    }
+
+
 }

--- a/src/test/kotlin/blackjack/model/PlayerTest.kt
+++ b/src/test/kotlin/blackjack/model/PlayerTest.kt
@@ -66,14 +66,14 @@ class PlayerTest {
         val dealer = Dealer()
         val player = Player("pobi", 10000)
 
-        //initial draw
+        // initial draw
         player.drawCard(listOf(Card(Rank.SIX, Suit.SPADES), Card(Rank.KING, Suit.HEARTS))) // total = 16
-        dealer.drawCard(listOf(Card(Rank.FIVE, Suit.CLUBS), Card(Rank.FOUR, Suit.DIAMONDS))) //total = 9
+        dealer.drawCard(listOf(Card(Rank.FIVE, Suit.CLUBS), Card(Rank.FOUR, Suit.DIAMONDS))) // total = 9
 
-        //player draws again
+        // player draws again
         player.drawCard(cards = listOf(Card(Rank.FIVE, Suit.DIAMONDS))) // total = 21
 
-        //dealer draws again
+        // dealer draws again
         dealer.drawCard(listOf(Card(Rank.FIVE, Suit.SPADES))) // total = 14
 
         player.updateWinningMoney(dealer)
@@ -92,6 +92,4 @@ class PlayerTest {
 
         assertThat(player.returnWinningMoney()).isEqualTo(-10000)
     }
-
-
 }

--- a/src/test/kotlin/blackjack/model/PlayersTest.kt
+++ b/src/test/kotlin/blackjack/model/PlayersTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 class PlayersTest {
     @Test
     fun `should return list of players`() {
-        val players = Players(listOf(Player("Player1",10000), Player("Player2",20000)))
+        val players = Players(listOf(Player("Player1", 10000), Player("Player2", 20000)))
         assertEquals(2, players.toList().size)
     }
 }

--- a/src/test/kotlin/blackjack/model/PlayersTest.kt
+++ b/src/test/kotlin/blackjack/model/PlayersTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 class PlayersTest {
     @Test
     fun `should return list of players`() {
-        val players = Players(listOf(Player("Player1"), Player("Player2")))
+        val players = Players(listOf(Player("Player1",10000), Player("Player2",20000)))
         assertEquals(2, players.toList().size)
     }
 }


### PR DESCRIPTION
### Add Betting and Earnings Calculation to Blackjack Game

**Features Added:**

- Players now place bets at the start of the game.
- Earnings are calculated after comparing each player’s final result with the dealer.
- Implemented rules for betting outcomes according to requirements:
- If a player busts (total > 21), they lose their entire bet.
- If a dealer busts (total > 21), all the players get their bets
- If a player has Blackjack on initial two cards, they earn 1.5x their bet.
- If both player and dealer have Blackjack, the player’s bet is returned.
- If it’s a tie (non-Blackjack), player earnings are zero. (Tie conditions outside Blackjack were not explicitly mentioned, so earnings are set to zero by default in those cases.)
- Dealer’s win or lose status is derived from players’ results.

Thank you very much for your time reviewing this update!
Looking forward to your feedback. Have a great day! 😊